### PR TITLE
Update README.md - cosmetic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
     - Go to `Users` -> `Organization Credentials` and copy your Organization Username and Password
   - In your own instance of SUSE Manager
     - Go to `Admin` -> `Setup Wizard` -> `Organization Credentials`
-    - Click on `Add new credential` An use the Username and Paswword provided in SCC and obtained in previous step
+    - Click `Add new credential` and use the Username and Paswword provided in SCC and obtained in previous step
 - Sync the SLL/SLES-ES channels in SUSE Manager
   - Go to `Admin` -> `Setup Wizard` -> `Products`
   - Select the SUSE Liberty Linux Channels that you will use:
@@ -35,7 +35,7 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
   - Then, to the new Activation Key, add the following content:
     - `Description`: with some tech describing the acitvation key
     - `Key`: With the identifier for the key, for example `el9-default` for your EL9 systems
-      - Note: Keys will have a numeric prefix depending on the organization so that there are not two equal keys in the same SUSE Manager
+      - Note: Keys will have a numeric prefix depending on the organization so that there are not to equal keys in the same SUSE Manager
     - `Usage`: Leave blank
     - `Base Channel`: Select one base channel. Depending on your EL version the base channel will be:
         - EL7: `RHEL x86_64 Server 7`
@@ -54,8 +54,8 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
     - `Label`: provide a label to the channel, for example `el-2-sll`
     - `Description`: provide some descriptive text
     - `SLS Contents`: In here you have to copy the contents from the [init.sls](init.sls) file in this repository and paste them in the box
-    - Once completed all the stepsm, click `Create Config State Channel` and you will have the channel created
-  - Note: with the contents of `init.sls` in this repository the state will:
+    - Once completed all the steps, click `Create Config State Channel` and you will have the channel created
+  - Note: with the contents of init.sls in this repository the state will:
     - remove `/usr/share/redhat-release`: DONE
     - remove `/etc/dnf/protected.d/redhat-release.conf`: DONE
     - install SLL package: DONE
@@ -78,9 +78,9 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
       - `SSH Port`: Leave blank to use default, which is `22`
       - `User`: type user or leave blank for `root`
       - `Authentication Method`: Select if you want to use `password` or provide a `SSH Private Key`
-        - `Password`: If this was selected please provide the password to access the system
-        - `SSH Private Key`: If this was selected please provide the file with the private key
-          - `SSH Private Key Passphrase`: In case a private key was provided that requires a passphrase to unlock, please provide it here.
+        - `Password`: If this was selected provide the password to access the system
+        - `SSH Private Key`: If this was selected provide the file with the private key
+          - `SSH Private Key Passphrase`: In case a private key was provided that requires a passphrase to unlock, provide it here.
       - `Activation Key`: Select from the menu the Activation key to be used, for example `el9-default`.
       - `Reactivation Key`: Leave blank it wont be used here
       - `Proxy`: Leave as `None` as it is used for the SUSE Manager specific proxies.
@@ -88,10 +88,10 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
       - Note: A message will show in the top of the page stating that the system is being registered, or "bootstraped" in SUSE Manager parlance.
   - Onboarding a new system using a *bootstrap script* with an assigned Activation key
     - Note: This is intended to be used for mass registration
-    - In the left menu, go to `Admin` -> `Manager Configuration` -> `Bootstrap Script`, to reach the bootstrap script configuration. Let's fill the fields here.
+    - In the left menu, go to `Admin` -> `Manager Configuration` -> `Bootstrap Script`, to reach the bootstrap script configuration. Fill the fields here.
       - `SUSE Manager server hostname`: This should be set to the hostname that the client systems (a.k.a. minions) will use to reach SUSE Manager, as well as the SUSE Manager hostname
         - Note: a Certificate will be used associated to this name for the client systems, as it was configured in the initial setup. If it's changed, a new certificate shall be created
-      - `SSL cert location`: Path, in the SUSE Manager server, to the filename provided as a certificate to register it. Please keep it as it is.
+      - `SSL cert location`: Path, in the SUSE Manager server, to the filename provided as a certificate to register it. Keep it as it is.
       - `Bootstrap using Salt`: Select this checkbox to apply salt states, like the one we added via configuration channel. It is required to perform the conversion.
       - `Enable Client GPG checking`: Select this checkbox to ensure all packages installed come from the proper sources, in this case, SUSE Liberty Linux signed packages.
       - `Enable Remote Configuration`: Leave unchecked.

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
     - EL7: `SUSE Linux Enterprise Server with Expanded Support 7 x86_64`
     - EL8: `RHEL or SLES ES or CentOS 8 Base`
     - EL9: `RHEL and Liberty 9 Base`
-  - Click on th top right button `+ Add products`
+  - Click the top right button `+ Add products`
   - You can check progress by accessing the SUSE Manager machine via SSH and monitoring the logs using `tail -f /var/log/rhn/reposync/*`
 - Create one Activation Key per SUSE Liberty Linux channel
   - Note: Activation Keys are the way to register systems and assign them to the software and configuration channels corresponding to them
-  - Go to `Systems` -> `Activation Keys` and click on the top right message `+ Create key`
+  - Go to `Systems` -> `Activation Keys` and click the top right message `+ Create key`
   - Then, to the new Activation Key, add the following content:
     - `Description`: with some tech describing the acitvation key
     - `Key`: With the identifier for the key, for example `el9-default` for your EL9 systems
-      - Note: Keis will have a nimeric prefix depending ont he organization so that there are not to equal keys in the same SUSE Manager
+      - Note: Keys will have a numeric prefix depending on the organization so that there are not two equal keys in the same SUSE Manager
     - `Usage`: Leave blank
     - `Base Channel`: Select one base channel. Depending on your EL version the base channel will be:
         - EL7: `RHEL x86_64 Server 7`
@@ -46,16 +46,16 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
     - `Add-On system type`: Leave all blank
     - `Contact Method`: Default
     - `Universal Default`: Leave unchecked
-    - Click on `Create Activation Key`
+    - Click `Create Activation Key`
 - Create a configuration channel to automate the "liberation" process
-  - Go to `Configuration` -> `Channels` and click on the top right `+ Create State Channel`
+  - Go to `Configuration` -> `Channels` and click the top right `+ Create State Channel`
     - Note: This will create a channel that will run Salt States in your system. Later on we will assign it directly to an Activation Key to automatically proceed with the conversion to SUSE Liberty Linux. It could also be assigned to already registered systems as described below
     - `Name`: provide a name to the channel, for example `Convert EL 2 SLL`
     - `Label`: provide a label to the channel, for example `el-2-sll`
     - `Description`: provide some descriptive text
     - `SLS Contents`: In here you have to copy the contents from the [init.sls](init.sls) file in this repository and paste them in the box
-    - Once completed all the stepsm, click on `Create Config State Channel` and you will have the channel created
-  - Note: with the contents of init.sls in this repository The state will:
+    - Once completed all the stepsm, click `Create Config State Channel` and you will have the channel created
+  - Note: with the contents of `init.sls` in this repository the state will:
     - remove `/usr/share/redhat-release`: DONE
     - remove `/etc/dnf/protected.d/redhat-release.conf`: DONE
     - install SLL package: DONE
@@ -64,11 +64,11 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
   - Go to `Systems` -> `Activation Keys`
   - Select the Activation Key, for example `el9-default` for your EL9 systems
     - In the Activation Key page go to `Configuration` -> `Subscribe to Channel`
-    - Select the Channel name, for example `el-2-sll` and click on the low right button `Continue`
+    - Select the Channel name, for example `el-2-sll` and click the low right button `Continue`
   - Note: Now, when registering any system with this Activation Key, it will automatically subscribe it to the right channels and, by "applying high state", run the conversion to SUSE Liberty Linux.
 
 ### Registering a new system to SUSE Manager and proceed to the conversion
-- There are two wais to onboard, or register, a new system (a.k.a. minion) with the activation key
+- There are two ways to onboard, or register, a new system (a.k.a. minion) with the activation key
   - Onboarding a new system *using webUI* and selecting the activation key
     - Note: This is intended for a one-off registration or for testing purposes
     - Go to `Systems` -> `Bootstraping`
@@ -84,7 +84,7 @@ https://hackweek.opensuse.org/23/projects/use-uyuni-to-migrate-el-linux-to-sll
       - `Activation Key`: Select from the menu the Activation key to be used, for example `el9-default`.
       - `Reactivation Key`: Leave blank it wont be used here
       - `Proxy`: Leave as `None` as it is used for the SUSE Manager specific proxies.
-      - Click on the `+ Bootstrap` button to start the registration
+      - Click the `+ Bootstrap` button to start the registration
       - Note: A message will show in the top of the page stating that the system is being registered, or "bootstraped" in SUSE Manager parlance.
   - Onboarding a new system using a *bootstrap script* with an assigned Activation key
     - Note: This is intended to be used for mass registration


### PR DESCRIPTION
Some typos fixed.

I propose replacing `click on button xxx` with just `click button xxx` (without `on`) as we usually do in the Uyuni/SUSE Manager product documentation.